### PR TITLE
Fix for loops in dsl

### DIFF
--- a/src/FsSpreadsheet/DSL/ColumnBuilder.fs
+++ b/src/FsSpreadsheet/DSL/ColumnBuilder.fs
@@ -24,6 +24,9 @@ type ColumnBuilder() =
     member inline _.Yield(cs: ColumnElement list) =
         Missing.ok cs
 
+    member inline _.Yield(cs: Missing<ColumnElement list>) =
+        cs
+
     member inline _.Yield(c: Missing<CellElement>) =
         match c with 
         | Ok ((v,Some i),messages) -> 
@@ -60,15 +63,15 @@ type ColumnBuilder() =
         Missing.ok [ColumnElement.UnindexedCell v]
 
 
-    member inline this.YieldFrom(ns: Missing<CellElement> seq) =   
+    member inline this.YieldFrom(ns: Missing<ColumnElement list> seq) =   
         ns
         |> Seq.fold (fun state we ->
-            this.Combine(state,this.Yield(we))
+            this.Combine(state,we)
 
         ) ColumnBuilder.Empty
 
 
-    member inline this.For(vs : seq<'T>, f : 'T -> Missing<CellElement>) =
+    member inline this.For(vs : seq<'T>, f : 'T -> Missing<ColumnElement list>) =
         vs
         |> Seq.map f
         |> this.YieldFrom

--- a/src/FsSpreadsheet/DSL/RowBuilder.fs
+++ b/src/FsSpreadsheet/DSL/RowBuilder.fs
@@ -24,6 +24,9 @@ type RowBuilder() =
     member inline _.Yield(cs: RowElement list) =
         Missing.ok cs
 
+    member inline _.Yield(cs: Missing<RowElement list>) =
+        cs
+
     member inline _.Yield(c: Missing<CellElement>) =
         match c with 
         | Ok ((v,Some i),messages) -> 
@@ -60,15 +63,15 @@ type RowBuilder() =
         Missing.ok [RowElement.UnindexedCell v]
 
 
-    member inline this.YieldFrom(ns: Missing<CellElement> seq) =   
+    member inline this.YieldFrom(ns: Missing<RowElement list> seq) =   
         ns
         |> Seq.fold (fun state we ->
-            this.Combine(state,this.Yield(we))
+            this.Combine(state,we)
 
         ) RowBuilder.Empty
 
 
-    member inline this.For(vs : seq<'T>, f : 'T -> Missing<CellElement>) =
+    member inline this.For(vs : seq<'T>, f : 'T -> Missing<RowElement list>) =
         vs
         |> Seq.map f
         |> this.YieldFrom

--- a/src/FsSpreadsheet/DSL/SheetBuilder.fs
+++ b/src/FsSpreadsheet/DSL/SheetBuilder.fs
@@ -23,6 +23,9 @@ type SheetBuilder(name : string) =
 
     member inline _.Yield(cs: SheetElement list) =
         Missing.ok cs
+   
+    member inline _.Yield(cs: Missing<SheetElement list>) =
+        cs
 
     member inline _.Yield(c: Missing<RowElement list>) =
         match c with 
@@ -54,50 +57,15 @@ type SheetBuilder(name : string) =
     member inline _.Yield(cs: ColumnBuilder) =
         Missing.ok [SheetElement.UnindexedColumn []]
 
-    member inline this.YieldFrom(ns: (RowElement list) seq) =   
+
+    member inline this.YieldFrom(ns: Missing<SheetElement list> seq) =   
         ns
         |> Seq.fold (fun state we ->
-            this.Combine(state,this.Yield(we))
+            this.Combine(state,we)
 
         ) SheetBuilder.Empty
 
-    member inline this.YieldFrom(ns: Missing<RowElement list> seq) =   
-        ns
-        |> Seq.fold (fun state we ->
-            this.Combine(state,this.Yield(we))
-
-        ) SheetBuilder.Empty
-
-    member inline this.YieldFrom(ns: (ColumnElement list) seq) =   
-        ns
-        |> Seq.fold (fun state we ->
-            this.Combine(state,this.Yield(we))
-
-        ) SheetBuilder.Empty
-
-    member inline this.YieldFrom(ns: Missing<ColumnElement list> seq) =   
-        ns
-        |> Seq.fold (fun state we ->
-            this.Combine(state,this.Yield(we))
-
-        ) SheetBuilder.Empty
-
-    member inline this.For(vs : seq<'T>, f : 'T -> Missing<RowElement list>) =
-        vs
-        |> Seq.map f
-        |> this.YieldFrom
-
-    member inline this.For(vs : seq<'T>, f : 'T -> RowElement list) =
-        vs
-        |> Seq.map f
-        |> this.YieldFrom
-
-    member inline this.For(vs : seq<'T>, f : 'T -> Missing<ColumnElement list>) =
-        vs
-        |> Seq.map f
-        |> this.YieldFrom
-
-    member inline this.For(vs : seq<'T>, f : 'T -> ColumnElement list) =
+    member inline this.For(vs : seq<'T>, f : 'T -> Missing<SheetElement list>) =
         vs
         |> Seq.map f
         |> this.YieldFrom

--- a/src/FsSpreadsheet/DSL/WorkbookBuilder.fs
+++ b/src/FsSpreadsheet/DSL/WorkbookBuilder.fs
@@ -23,7 +23,9 @@ type WorkbookBuilder() =
 
     member inline _.Yield(cs: WorkbookElement list) =
         Missing.ok cs
-
+    
+    member inline _.Yield(cs: Missing<WorkbookElement list> ) =
+        cs
 
     member inline _.Yield(c: Missing<SheetElement list>) =
         match c with 
@@ -49,38 +51,20 @@ type WorkbookBuilder() =
     member inline _.Yield(cs: string * SheetElement list) =
         Missing.ok [WorkbookElement.NamedSheet (cs)]
 
-    //member inline this.Yield(n: 'a when 'a :> System.IFormattable) = 
-    //    let v = DataType.InferCellValue n
-    //    Missing.ok [RowElement.UnindexedCell v]
 
-    //member inline _.Yield(s : string) = 
-    //    let v = DataType.InferCellValue s
-    //    Missing.ok [RowElement.UnindexedCell v]
-
-    member inline this.YieldFrom(ns: (SheetElement list) seq) =   
+    member inline this.YieldFrom(ns: Missing<WorkbookElement list> seq) =   
         ns
         |> Seq.fold (fun state we ->
-            this.Combine(state,this.Yield(we))
-
-        ) WorkbookBuilder.Empty
-
-    member inline this.YieldFrom(ns: Missing<SheetElement list> seq) =   
-        ns
-        |> Seq.fold (fun state we ->
-            this.Combine(state,this.Yield(we))
+            this.Combine(state,we)
 
         ) WorkbookBuilder.Empty
 
 
-    member inline this.For(vs : seq<'T>, f : 'T -> Missing<SheetElement list>) =
+    member inline this.For(vs : seq<'T>, f : 'T -> Missing<WorkbookElement list>) =
         vs
         |> Seq.map f
         |> this.YieldFrom
 
-    member inline this.For(vs : seq<'T>, f : 'T -> SheetElement list) =
-        vs
-        |> Seq.map f
-        |> this.YieldFrom
 
     member inline this.Run(children: Missing<WorkbookElement list>) =
         match children with 


### PR DESCRIPTION
For loops now working in dsl: 

```fsharp

workbook {

    for number in [1;2] do
        sheet (string number) {

            for number in [1;2] do

                row {

                    for number in [1;2] do
                        number
                }

        }
}
```

---->

```
Ok
    (Workbook
       [NamedSheet
          ("1",
           [UnindexedRow
              [UnindexedCell (Number, "1"); UnindexedCell (Number, "2")];
            UnindexedRow
              [UnindexedCell (Number, "1"); UnindexedCell (Number, "2")]]);
        NamedSheet
          ("2",
           [UnindexedRow
              [UnindexedCell (Number, "1"); UnindexedCell (Number, "2")];
            UnindexedRow
              [UnindexedCell (Number, "1"); UnindexedCell (Number, "2")]])],
     [])

```

