### PR TITLE
Allow message type to be exception

### DIFF
--- a/src/FsSpreadsheet/DSL/CellBuilder.fs
+++ b/src/FsSpreadsheet/DSL/CellBuilder.fs
@@ -32,7 +32,7 @@ type CellBuilder() =
 
     member this.SignMessages (messages : Message list) : Message list =
         messages
-        |> List.map (sprintf "In Cell: %s")
+        |> List.map (fun m -> m.MapText (sprintf "In Cell: %s"))
 
     member inline this.Yield(n: RequiredSource<unit>) = 
         n
@@ -66,12 +66,12 @@ type CellBuilder() =
     member inline this.Yield(s : string option) : SheetEntity<Value list> =
         match s with
         | Option.Some s -> this.Yield s
-        | None -> NoneRequired ["Value is missing"]
+        | None -> NoneRequired [message "Value is missing"]
 
     member inline this.Yield(n: 'a option when 'a :> System.IFormattable) = 
         match n with
         | Option.Some s -> this.Yield s
-        | None -> NoneRequired ["Value is missing"]
+        | None -> NoneRequired [message "Value is missing"]
 
     member inline this.YieldFrom(ns: SheetEntity<Value list> seq) =   
         ns
@@ -154,7 +154,7 @@ type CellBuilder() =
             | NoneRequired m -> NoneOptional m
             | se -> se
         with
-        | err -> NoneOptional [err.Message]
+        | err -> NoneOptional [message err.Message]
 
     member inline this.Run(children: Expr<RequiredSource<SheetEntity<Value list>>>) =
         try 
@@ -162,7 +162,7 @@ type CellBuilder() =
             | NoneOptional m -> NoneRequired m
             | se -> se
         with
-        | err -> NoneOptional [err.Message]
+        | err -> NoneOptional [message err.Message]
 
     member inline this.Run(children: Expr<SheetEntity<Value list>>) =
         this.AsCellElement (eval<SheetEntity<Value list>> children)

--- a/src/FsSpreadsheet/DSL/ColumnBuilder.fs
+++ b/src/FsSpreadsheet/DSL/ColumnBuilder.fs
@@ -22,7 +22,7 @@ type ColumnBuilder() =
 
     member this.SignMessages (messages : Message list) : Message list =
         messages
-        |> List.map (sprintf "In Column: %s")
+        |> List.map (fun m -> m.MapText (sprintf "In Column: %s"))
 
     member inline _.Yield(c: ColumnElement) =
         SheetEntity.ok [c]
@@ -175,7 +175,7 @@ type ColumnBuilder() =
             | NoneRequired m -> NoneOptional m
             | se -> se
         with
-        | err -> NoneOptional [err.Message]
+        | err -> NoneOptional [message err.Message]
 
     member inline this.Run(children: Expr<RequiredSource<SheetEntity<ColumnElement list>>>) =
         try 
@@ -183,7 +183,7 @@ type ColumnBuilder() =
             | NoneOptional m -> NoneRequired m
             | se -> se
         with
-        | err -> NoneOptional [err.Message]
+        | err -> NoneOptional [message err.Message]
 
     member inline this.Run(children: Expr<SheetEntity<ColumnElement list>>) =
         (eval<SheetEntity<ColumnElement list>> children).Value

--- a/src/FsSpreadsheet/DSL/DSL.fs
+++ b/src/FsSpreadsheet/DSL/DSL.fs
@@ -39,7 +39,7 @@ type DSL =
             DSL.opt elem
         with
         | err -> 
-            NoneOptional([err.Message])
+            NoneOptional([message err.Message])
 
     /// Drops the cell with the given message
     static member dropCell message : SheetEntity<Value> = NoneRequired [message]

--- a/src/FsSpreadsheet/DSL/Operators.fs
+++ b/src/FsSpreadsheet/DSL/Operators.fs
@@ -57,14 +57,14 @@ module Operators =
     ///
     /// If expression does fail, returns a missing required value
     let inline (!!) (v : 'T) : SheetEntity<Value> =
-        let f = fun s -> NoneRequired([s])
+        let f = fun s -> NoneRequired([message s])
         parseAny f v
 
     /// Optional value operator
     ///
     /// If expression does fail, returns a missing optional value
     let inline (!?) (v : 'T) : SheetEntity<Value> =
-        let f = fun s -> NoneOptional([s])
+        let f = fun s -> NoneOptional([message s])
         parseAny f v 
 
     /// Optional operators for cell, row, column and sheet expressions

--- a/src/FsSpreadsheet/DSL/RowBuilder.fs
+++ b/src/FsSpreadsheet/DSL/RowBuilder.fs
@@ -19,7 +19,7 @@ type RowBuilder() =
 
     member this.SignMessages (messages : Message list) : Message list =
         messages
-        |> List.map (sprintf "In Row: %s")
+        |> List.map (fun m -> m.MapText (sprintf "In Row: %s"))
 
     member inline this.Yield(n: RequiredSource<unit>) = 
         n
@@ -163,7 +163,7 @@ type RowBuilder() =
             | NoneRequired m -> NoneOptional m
             | se -> se
         with
-        | err -> NoneOptional [err.Message]
+        | err -> NoneOptional [message err.Message]
 
     member inline this.Run(children: Expr<RequiredSource<SheetEntity<RowElement list>>>) =
         try 
@@ -171,7 +171,7 @@ type RowBuilder() =
             | NoneOptional m -> NoneRequired m
             | se -> se
         with
-        | err -> NoneOptional [err.Message]
+        | err -> NoneOptional [message err.Message]
 
     member inline this.Run(children: Expr<SheetEntity<RowElement list>>) =
         (eval<SheetEntity<RowElement list>> children).Value

--- a/src/FsSpreadsheet/DSL/SheetBuilder.fs
+++ b/src/FsSpreadsheet/DSL/SheetBuilder.fs
@@ -16,7 +16,7 @@ type SheetBuilder(name : string) =
 
     member this.SignMessages (messages : Message list) : Message list =
         messages
-        |> List.map (sprintf "In Sheet %s: %s" name)
+        |> List.map (fun m -> m.MapText (sprintf "In Sheet %s: %s" name))
 
     member inline _.Yield(se: SheetElement) =
         SheetEntity.ok [se]

--- a/src/FsSpreadsheet/DSL/TableBuilder.fs
+++ b/src/FsSpreadsheet/DSL/TableBuilder.fs
@@ -18,7 +18,7 @@ type TableBuilder(name : string) =
 
     member this.SignMessages (messages : Message list) : Message list =
         messages
-        |> List.map (sprintf "In Sheet %s: %s" name)
+        |> List.map (fun m -> m.MapText (sprintf "In Sheet %s: %s" name))
 
     member inline _.Yield(se: TableElement) =
         SheetEntity.ok [se]

--- a/src/FsSpreadsheet/DSL/WorkbookBuilder.fs
+++ b/src/FsSpreadsheet/DSL/WorkbookBuilder.fs
@@ -16,7 +16,7 @@ type WorkbookBuilder() =
 
     member this.SignMessages (messages : Message list) : Message list =
         messages
-        |> List.map (sprintf "In Workbook: %s")
+        |> List.map (fun m -> m.MapText (sprintf "In Workbook: %s"))
 
     member inline _.Yield(c: WorkbookElement) =
         SheetEntity.ok [c]


### PR DESCRIPTION
Messages yielded by DSL can now not only be string but also exceptions.