### PR TITLE
#31 No FsRows when read from file

### DIFF
--- a/src/FsSpreadsheet.ExcelIO/FsExtensions.fs
+++ b/src/FsSpreadsheet.ExcelIO/FsExtensions.fs
@@ -199,7 +199,11 @@ module FsExtensions =
                 )
 
             sheets
-            |> Seq.fold (fun wb sheet -> FsWorkbook.addWorksheet sheet wb) (new FsWorkbook())
+            |> Seq.fold (
+                fun wb sheet -> 
+                    sheet.RescanRows()      // we need this to have all FsRows present in the final FsWorksheet
+                    FsWorkbook.addWorksheet sheet wb
+            ) (new FsWorkbook())
 
         /// <summary>
         /// Creates an FsWorkbook from a given Stream to an XlsxFile.

--- a/tests/FsSpreadsheet.ExcelIO.Tests/FsExtensions.fs
+++ b/tests/FsSpreadsheet.ExcelIO.Tests/FsExtensions.fs
@@ -159,6 +159,9 @@ let fsExtensionTests =
                 testCase "Worksheet SwateTemplateMetadata from 2EXT02_Protein has correct value" <| fun _ ->
                     let v = tf2Worksheet.Value.CellCollection.TryGetCell(1,1).Value.Value
                     Expect.equal v "Id" "value is not equal"
+                testCase "Worksheet SwateTemplateMetadata from 2EXT02_Protein has FsRows" <| fun _ ->
+                    let rows = tf2Worksheet.Value.Rows
+                    Expect.isGreaterThan rows.Length 0 "Worksheet SwateTemplateMetadata from 2EXT02_Protein has no FsRows"
             ]
         ]
     ]


### PR DESCRIPTION
When creating an FsWorkbook from an Xlsx file, it has no FsRows. This PR

- lets `FsWorkbook.fromXlsxStream` call `.RescanRows()` on every worksheet 
  - which leads to incorporating all FsRows into the worksheet
- fixes #31