### PR TITLE
Increase fable javascript code quality

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Spreadsheet creation and manipulation in FSharp",
   "type": "module",
   "scripts": {
+    "fable-js": "dotnet fable ./src/FsSpreadsheet -o ./js",
     "pretest": "dotnet fable tests/FsSpreadsheet.Tests -o tests/FsSpreadsheet.JsNativeTests/fable",
     "test": "mocha tests/FsSpreadsheet.JsNativeTests/fable",
     "posttest": "mocha tests/FsSpreadsheet.JsNativeTests"

--- a/src/FsSpreadsheet.ExcelIO/FsExtensions.fs
+++ b/src/FsSpreadsheet.ExcelIO/FsExtensions.fs
@@ -56,7 +56,7 @@ module FsExtensions =
         member self.ToXlsxTable(cells : FsCellsCollection) = 
 
             let columns =
-                self.FieldNames(cells)
+                self.GetFieldNames(cells)
                 |> Seq.map (fun kv -> 
                     Table.TableColumn.create (1 + kv.Value.Index |> uint) kv.Value.Name
                 )

--- a/src/FsSpreadsheet.Interactive/FsSparseMatrix.fs
+++ b/src/FsSpreadsheet.Interactive/FsSparseMatrix.fs
@@ -1,5 +1,6 @@
-﻿namespace FsSpreadsheet
+﻿namespace FsSpreadsheet.Interactive
 
+open FsSpreadsheet
 
 /// A FsSparseMatrix
 type FsSparseMatrix<'T>(defaultEmptyValue: 'T,sparseValues : 'T array, sparseRowOffsets : int array, ncols:int, columnValues: int array) =     

--- a/src/FsSpreadsheet.Interactive/FsSpreadsheet.Interactive.fsproj
+++ b/src/FsSpreadsheet.Interactive/FsSpreadsheet.Interactive.fsproj
@@ -30,6 +30,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Compile Include="FsSparseMatrix.fs" />
     <Compile Include="Formatters.fs" />
     <Compile Include="Extension.fs" />
     <None Include="..\..\docs\img\logo.png" Pack="true" PackagePath="\" />

--- a/src/FsSpreadsheet/Cells/FsCell.fs
+++ b/src/FsSpreadsheet/Cells/FsCell.fs
@@ -55,7 +55,7 @@ type FsCell (value : IConvertible, ?dataType : DataType, ?address : FsAddress) =
     let mutable _columnIndex : int = address |> Option.map (fun a -> a.ColumnNumber) |> Option.defaultValue 0
 
 
-    ///// Creates an empty FsCell, set at row 1, column 1 (1-based).
+    /// Creates an empty FsCell, set at row 0, column 0 (1-based).
     static member empty () = FsCell ("", DataType.Empty, FsAddress(0,0))
 
     ///// Creates an FsCell of `DataType` `Number`, with the given value, set at row 1, column 1 (1-based).

--- a/src/FsSpreadsheet/Cells/FsCell.fs
+++ b/src/FsSpreadsheet/Cells/FsCell.fs
@@ -40,29 +40,23 @@ type DataType =
 /// <summary>
 /// Creates an FsCell of `DataType` dataType, with value of type `string`, and `FsAddress` address.
 /// </summary>
-type FsCell (value : IConvertible, dataType : DataType, address : FsAddress) =
+type FsCell (value : IConvertible, ?dataType : DataType, ?address : FsAddress) =
     
     // TODO: Maybe save as IConvertible
     let mutable _cellValue = string value
-    let mutable _dataType = dataType
+    let mutable _dataType = dataType |> Option.defaultValue DataType.String
     let mutable _comment  = ""
     let mutable _hyperlink = ""
     let mutable _richText = ""
     let mutable _formulaA1 = ""
     let mutable _formulaR1C1 = ""
 
-    let mutable _rowIndex : int = address.RowNumber
-    let mutable _columnIndex : int = address.ColumnNumber
+    let mutable _rowIndex : int = address |> Option.map (fun a -> a.RowNumber) |> Option.defaultValue 0
+    let mutable _columnIndex : int = address |> Option.map (fun a -> a.ColumnNumber) |> Option.defaultValue 0
 
-
-    // ------------------------
-    // ALTERNATIVE CONSTRUCTORS
-    // ------------------------
-
-    new (value : IConvertible) = FsCell (string value, DataType.String, FsAddress(0,0))
 
     ///// Creates an empty FsCell, set at row 1, column 1 (1-based).
-    //new () = FsCell ("", DataType.Empty, FsAddress(0,0))
+    static member empty () = FsCell ("", DataType.Empty, FsAddress(0,0))
 
     ///// Creates an FsCell of `DataType` `Number`, with the given value, set at row 1, column 1 (1-based).
     //new (value : int) = FsCell (string value, DataType.Number, FsAddress(0,0))

--- a/src/FsSpreadsheet/FsColumn.fs
+++ b/src/FsSpreadsheet/FsColumn.fs
@@ -21,6 +21,7 @@ type FsColumn (rangeAddress : FsRangeAddress, cells : FsCellsCollection)=
     // Creation
     // ----------
 
+    /// Creates an empty FsColumn, ranging from row 0, column 0 to row 0, column (1-based).
     static member empty() = FsColumn (FsRangeAddress(FsAddress(0,0),FsAddress(0,0)),FsCellsCollection())
 
     /// <summary>

--- a/src/FsSpreadsheet/FsColumn.fs
+++ b/src/FsSpreadsheet/FsColumn.fs
@@ -3,26 +3,31 @@
 open System.Collections.Generic
 open System.Collections
 
-
+open Fable.Core
 // Type based on the type XLRow used in ClosedXml
 /// <summary>
 /// Creates an FsColumn from the given FsRangeAddress, consisting of FsCells within a given FsCellsCollection, and a styleValue.
 /// </summary>
 /// <remarks>The FsCellsCollection must only cover 1 column!</remarks>
 /// <exception cref="System.Exception">if given FsCellsCollection has more than 1 column.</exception>
+[<AttachMembers>]
 type FsColumn (rangeAddress : FsRangeAddress, cells : FsCellsCollection)= 
 
-    inherit FsRangeBase(rangeAddress, null)
+    inherit FsRangeBase(rangeAddress)
 
     let cells = cells
 
-    new() = FsColumn (FsRangeAddress(FsAddress(0,0),FsAddress(0,0)),FsCellsCollection())
+    // ----------
+    // Creation
+    // ----------
+
+    static member empty() = FsColumn (FsRangeAddress(FsAddress(0,0),FsAddress(0,0)),FsCellsCollection())
 
     /// <summary>
     /// Create an FsColumn from a given FsCellsCollection and an columnColumn.
     /// </summary>
     /// <remarks>The appropriate range of the cells (i.e. minimum colIndex and maximum colIndex) is derived from the FsCells with the matching rowIndex.</remarks>
-    new(index, (cells : FsCellsCollection)) = 
+    static member createAt(index : int32, (cells : FsCellsCollection)) = 
         let getIndexBy (f : (FsCell -> int) -> seq<FsCell> -> FsCell) = 
             match cells.GetCellsInColumn index |> Seq.length with
             | 0 -> 1
@@ -34,8 +39,6 @@ type FsColumn (rangeAddress : FsRangeAddress, cells : FsCellsCollection)=
         let minRowIndex = getIndexBy Seq.minBy
         let maxRowIndex = getIndexBy Seq.maxBy
         FsColumn (FsRangeAddress(FsAddress(minRowIndex, index),FsAddress(maxRowIndex, index)), cells)
-
-    new (columnRange : FsRangeColumn, cells : FsCellsCollection) = FsColumn(columnRange.RangeAddress,cells)
 
     interface IEnumerable<FsCell> with
         member this.GetEnumerator() : System.Collections.Generic.IEnumerator<FsCell> = this.Cells.GetEnumerator()
@@ -100,9 +103,9 @@ type FsColumn (rangeAddress : FsRangeAddress, cells : FsCellsCollection)=
     static member item rowIndex (column : FsColumn) =
         column.Item(rowIndex)
 
-    /// <summary>
-    /// Inserts the value at columnIndex as an FsCell. If there is an FsCell at the position, this FsCells and all the ones right to it are shifted to the right.
-    /// </summary>
+    ///// <summary>
+    ///// Inserts the value at columnIndex as an FsCell. If there is an FsCell at the position, this FsCells and all the ones /right /to it are shifted to the right.
+    ///// </summary>
     //member this.InsertValueAt(colIndex, (value : 'a)) =
     //    let cell = FsCell(value)
     //    cells.Add(int32 this.Index, int32 colIndex, cell)

--- a/src/FsSpreadsheet/FsRow.fs
+++ b/src/FsSpreadsheet/FsRow.fs
@@ -3,26 +3,31 @@
 open System.Collections.Generic
 open System.Collections
 
-
+open Fable.Core
 // Type based on the type XLRow used in ClosedXml
 /// <summary>
 /// Creates an FsRow from the given FsRangeAddress, consisting of FsCells within a given FsCellsCollection, and a styleValue.
 /// </summary>
 /// <remarks>The FsCellsCollection must only cover 1 row!</remarks>
 /// <exception cref="System.Exception">if given FsCellsCollection has more than 1 row.</exception>
-type FsRow (rangeAddress : FsRangeAddress, cells : FsCellsCollection, styleValue)= 
+[<AttachMembers>]
+type FsRow (rangeAddress : FsRangeAddress, cells : FsCellsCollection)= 
 
-    inherit FsRangeBase(rangeAddress, styleValue)
+    inherit FsRangeBase(rangeAddress)
 
     let cells = cells
 
-    new() = FsRow (FsRangeAddress(FsAddress(0,0),FsAddress(0,0)),FsCellsCollection(),null)
+    // ----------
+    // Creation
+    // ----------
+
+    static member empty() = FsRow (FsRangeAddress(FsAddress(0,0),FsAddress(0,0)),FsCellsCollection())
 
     /// <summary>
     /// Create an FsRow from a given FsCellsCollection and an rowIndex.
     /// </summary>
     /// <remarks>The appropriate range of the cells (i.e. minimum colIndex and maximum colIndex) is derived from the FsCells with the matching rowIndex.</remarks>
-    new(index, (cells : FsCellsCollection)) = 
+    static member createAt(index, (cells : FsCellsCollection)) = 
         let getIndexBy (f : (FsCell -> int) -> seq<FsCell> -> FsCell) = 
             match cells.GetCellsInRow index |> Seq.length with
             | 0 -> 1
@@ -33,7 +38,7 @@ type FsRow (rangeAddress : FsRangeAddress, cells : FsCellsCollection, styleValue
                 ).Address.ColumnNumber
         let minColIndex = getIndexBy Seq.minBy
         let maxColIndex = getIndexBy Seq.maxBy
-        FsRow (FsRangeAddress(FsAddress(index, minColIndex),FsAddress(index, maxColIndex)), cells, null)
+        FsRow (FsRangeAddress(FsAddress(index, minColIndex),FsAddress(index, maxColIndex)), cells)
 
     interface IEnumerable<FsCell> with
         member this.GetEnumerator() : System.Collections.Generic.IEnumerator<FsCell> = this.Cells.GetEnumerator()
@@ -71,7 +76,7 @@ type FsRow (rangeAddress : FsRangeAddress, cells : FsCellsCollection, styleValue
         let cells = self.Cells |> Seq.map (fun c -> c.Copy())
         let fcc = FsCellsCollection()
         fcc.Add cells
-        FsRow(ra, fcc, null)
+        FsRow(ra, fcc)
 
     /// <summary>
     /// Returns a deep copy of a given FsRow.

--- a/src/FsSpreadsheet/FsSpreadsheet.fsproj
+++ b/src/FsSpreadsheet/FsSpreadsheet.fsproj
@@ -6,7 +6,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Compile Include="FsSparseMatrix.fs" />
     <Compile Include="FsAddress.fs" />
     <Compile Include="Cells\FsCell.fs" />
     <Compile Include="Cells\FsCellsCollection.fs" />
@@ -50,6 +49,10 @@
 
   <ItemGroup>
 	<Content Include="*.fsproj; **\*.fs; **\*.fsi" PackagePath="fable\" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Fable.Core" Version="4.0.0" />
   </ItemGroup>
 
 </Project>

--- a/src/FsSpreadsheet/FsWorkbook.fs
+++ b/src/FsSpreadsheet/FsWorkbook.fs
@@ -39,14 +39,14 @@ type FsWorkbook() =
         workbook.Copy()
  
     /// <summary>
-    /// Adds an empty FsWorksheet with given name to the FsWorkbook.
+    /// Creates an empty FsWorksheet with given name and adds it to the FsWorkbook.
     /// </summary>
     member self.InitWorksheet(name : string) = 
         let sheet = FsWorksheet name
         _worksheets <- List.append _worksheets [sheet]
 
     /// <summary>
-    /// Adds an empty FsWorksheet with given name to an FsWorkbook.
+    /// Creates an empty FsWorksheet with given name and adds it to the FsWorkbook.
     /// </summary>
     static member initWorksheet (name : string) (workbook : FsWorkbook) = 
         workbook.InitWorksheet name

--- a/src/FsSpreadsheet/FsWorkbook.fs
+++ b/src/FsSpreadsheet/FsWorkbook.fs
@@ -1,9 +1,11 @@
 ﻿namespace FsSpreadsheet
 
-
+open Fable.Core
 /// <summary>
 /// Creates an empty FsWorkbook.
 /// </summary>
+
+[<AttachMembers>]
 type FsWorkbook() =
  
     let mutable _worksheets = []
@@ -39,15 +41,15 @@ type FsWorkbook() =
     /// <summary>
     /// Adds an empty FsWorksheet with given name to the FsWorkbook.
     /// </summary>
-    member self.AddWorksheet(name : string) = 
+    member self.InitWorksheet(name : string) = 
         let sheet = FsWorksheet name
         _worksheets <- List.append _worksheets [sheet]
 
     /// <summary>
     /// Adds an empty FsWorksheet with given name to an FsWorkbook.
     /// </summary>
-    static member addWorksheetWithName (name : string) (workbook : FsWorkbook) = 
-        workbook.AddWorksheet name
+    static member initWorksheet (name : string) (workbook : FsWorkbook) = 
+        workbook.InitWorksheet name
         workbook
 
     
@@ -94,6 +96,34 @@ type FsWorkbook() =
         workbook.GetWorksheets()
 
     /// <summary>
+    /// Returns the FsWorksheet with the given 1 based index if it exists. Else returns None.
+    /// </summary>
+    member self.TryGetWorksheetAt(index : int) =
+        _worksheets |> List.tryItem (index - 1)
+
+    /// <summary>
+    /// Returns the FsWorksheet with the given 1 based index if it exists in a given FsWorkbook. Else returns None.
+    /// </summary>
+    static member tryGetWorksheetAt (index : int) (workbook : FsWorkbook) =
+        workbook.TryGetWorksheetAt index
+
+    /// <summary>
+    /// Returns the FsWorksheet with the given 1 based index.
+    /// </summary>
+    /// <exception cref="System.Exception">if FsWorksheet with at position is not present in the FsWorkkbook.</exception>
+    member self.GetWorksheetAt(index : int) =
+        match self.TryGetWorksheetAt index with
+        | Some w -> w
+        | None -> failwith $"FsWorksheet at position {index} is not present in the FsWorkbook."
+
+    /// <summary>
+    /// Returns the FsWorksheet with the given the given 1 based indexk.
+    /// </summary>
+    /// <exception cref="System.Exception">if FsWorksheet with at position is not present in the FsWorkkbook.</exception>
+    static member getWorksheetAt (index : int) (workbook : FsWorkbook) =
+        workbook.GetWorksheetAt index
+
+    /// <summary>
     /// Returns the FsWorksheet with the given name if it exists in the FsWorkbook. Else returns None.
     /// </summary>
     member self.TryGetWorksheetByName(sheetName) =
@@ -134,22 +164,8 @@ type FsWorkbook() =
     /// <summary>
     /// Removes an FsWorksheet with given name from an FsWorkbook.
     /// </summary>
-    static member removeWorksheetByName (name : string) (workbook : FsWorkbook) =
+    static member removeWorksheet (name : string) (workbook : FsWorkbook) =
         workbook.RemoveWorksheet name
-        workbook
-
-    /// <summary>
-    /// Removes a given FsWorksheet.
-    /// </summary>
-    /// <exception cref="System.Exception">if FsWorksheet with given name is not present in the FsWorkkbook.</exception>
-    member self.RemoveWorksheet(sheet : FsWorksheet) =
-        self.RemoveWorksheet(sheet.Name)
-
-    /// <summary>
-    /// Removes a given FsWorksheet from an FsWorkbook.
-    /// </summary>
-    static member removeWorksheet (sheet : FsWorksheet) (workbook : FsWorkbook) =
-        workbook.RemoveWorksheet sheet
         workbook
 
     /// <summary>

--- a/src/FsSpreadsheet/Ranges/FsRange.fs
+++ b/src/FsSpreadsheet/Ranges/FsRange.fs
@@ -3,7 +3,7 @@
 
 type FsRange(rangeAddress : FsRangeAddress, styleValue) = 
 
-    inherit FsRangeBase(rangeAddress, styleValue)
+    inherit FsRangeBase(rangeAddress)
 
     new (rangeAddress : FsRangeAddress) = FsRange(rangeAddress, null)
     new (rangeBase : FsRangeBase) = FsRange(rangeBase.RangeAddress, null)

--- a/src/FsSpreadsheet/Ranges/FsRangeAddress.fs
+++ b/src/FsSpreadsheet/Ranges/FsRangeAddress.fs
@@ -210,9 +210,9 @@ type FsRangeAddress(firstAddress : FsAddress, lastAddress : FsAddress) =
     override self.ToString() =
         self.Range
 
-    member self.FirstAddress = _firstAddress
+    member self.FirstAddress : FsAddress = _firstAddress
 
-    member self.LastAddress = _lastAddress
+    member self.LastAddress : FsAddress = _lastAddress
 
     member self.Union(rangeAddress : FsRangeAddress) =
         self.Extend(rangeAddress.FirstAddress)

--- a/src/FsSpreadsheet/Ranges/FsRangeBase.fs
+++ b/src/FsSpreadsheet/Ranges/FsRangeBase.fs
@@ -1,7 +1,7 @@
 ﻿namespace FsSpreadsheet
 
 [<AbstractClass>][<AllowNullLiteral>]
-type FsRangeBase (rangeAddress : FsRangeAddress, styleValue) = 
+type FsRangeBase (rangeAddress : FsRangeAddress) = 
     //: XLStylizedBase, IXLRangeBase, IXLStylized
 
 
@@ -9,14 +9,11 @@ type FsRangeBase (rangeAddress : FsRangeAddress, styleValue) =
     let mutable _sortColumns = null
     let mutable _rangeAddress = rangeAddress
 
-    let mutable _styleValue = styleValue
 
     static let mutable IdCounter = 0;
     let _id = 
         IdCounter <- IdCounter + 1
         IdCounter
-
-    new (rangeAddress) = FsRangeBase(rangeAddress, null)
 
     //abstract member OnRangeAddressChanged : FsRangeAddress*FsRangeAddress -> unit 
     
@@ -78,7 +75,7 @@ type FsRangeBase (rangeAddress : FsRangeAddress, styleValue) =
     member self.Cells(cells : FsCellsCollection) = 
         cells.GetCells(self.RangeAddress.FirstAddress, self.RangeAddress.LastAddress)
        
-    member self.Cells(cells : FsCellsCollection, predicate : FsCell -> bool) = 
+    member self.CellsSelect(cells : FsCellsCollection, predicate : FsCell -> bool) = 
         cells.GetCells(self.RangeAddress.FirstAddress, self.RangeAddress.LastAddress, predicate)
      
      member self.ColumnCount() =

--- a/src/FsSpreadsheet/Ranges/FsRangeBase.fs
+++ b/src/FsSpreadsheet/Ranges/FsRangeBase.fs
@@ -75,8 +75,5 @@ type FsRangeBase (rangeAddress : FsRangeAddress) =
     member self.Cells(cells : FsCellsCollection) = 
         cells.GetCells(self.RangeAddress.FirstAddress, self.RangeAddress.LastAddress)
        
-    member self.CellsSelect(cells : FsCellsCollection, predicate : FsCell -> bool) = 
-        cells.GetCells(self.RangeAddress.FirstAddress, self.RangeAddress.LastAddress, predicate)
-     
      member self.ColumnCount() =
         _rangeAddress.LastAddress.ColumnNumber - _rangeAddress.FirstAddress.ColumnNumber + 1;

--- a/src/FsSpreadsheet/Ranges/FsRangeColumn.fs
+++ b/src/FsSpreadsheet/Ranges/FsRangeColumn.fs
@@ -3,7 +3,7 @@
 [<AllowNullLiteral>]
 type FsRangeColumn(rangeAddress) =
 
-    inherit FsRangeBase(rangeAddress, null)
+    inherit FsRangeBase(rangeAddress)
     
     //new () = 
     //    let range = FsRangeAddress(FsAddress(0,0),FsAddress(0,0))

--- a/src/FsSpreadsheet/Ranges/FsRangeRow.fs
+++ b/src/FsSpreadsheet/Ranges/FsRangeRow.fs
@@ -3,7 +3,7 @@
 [<AllowNullLiteral>]
 type FsRangeRow(rangeAddress) =
 
-    inherit FsRangeBase(rangeAddress, null)
+    inherit FsRangeBase(rangeAddress)
     
     //new () = 
     //    let range = FsRangeAddress(FsAddress(0,0),FsAddress(0,0))

--- a/src/FsSpreadsheet/SheetBuilder.fs
+++ b/src/FsSpreadsheet/SheetBuilder.fs
@@ -227,7 +227,7 @@ module SheetBuilder =
     type FsWorkbook with
 
         member self.Populate<'T>(name : string, data : seq<'T>, fields : FieldMap<'T> list) : unit =
-            self.AddWorksheet(name)
+            self.InitWorksheet(name)
             let sheet = self.GetWorksheets() |> Seq.find (fun s -> s.Name = name)
             FsWorksheet.populate(sheet, data, fields)
 

--- a/src/FsSpreadsheet/Tables/FsTableField.fs
+++ b/src/FsSpreadsheet/Tables/FsTableField.fs
@@ -128,12 +128,9 @@ type FsTableField (name : string, index : int, column : FsRangeColumn, totalsRow
     /// </summary>
     /// <param name="cellsCollection">The FsCellsCollection respective to the FsTableField where the data cells are taken from.</param>
     /// <param name="showHeaderRow">If the header row is shown or not.</param>
-    member this.DataCells (cellsCollection : FsCellsCollection, showHeaderRow : bool) =
-        // TO DO: Ask HLW: isn't this predicate pointless? If showHeaderRow is false, the code breaks as soon as trying to call .HeaderCell
-        //let predicate cell = (not showHeaderRow) && (this.HeaderCell(cellsCollection, showHeaderRow) <> cell)
-        let predicate = fun _ -> true
-        this.Column.CellsSelect(cellsCollection, predicate)
-        |> Seq.skip 1       // ClosedXML implementation never shows header cell
+    member this.DataCells (cellsCollection : FsCellsCollection) =        
+        this.Column.Cells(cellsCollection)
+        |> Seq.skip 1 // ClosedXML implementation never shows header cell
 
     /// <summary>
     /// Gets the collection of data cells for a given FsTableField. Excludes the header and footer cells.
@@ -141,5 +138,5 @@ type FsTableField (name : string, index : int, column : FsRangeColumn, totalsRow
     /// <param name="cellsCollection">The FsCellsCollection respective to the FsTableField where the data cells are taken from.</param>
     /// <param name="showHeaderRow">If the header row is shown or not.</param>
     /// <param name="tableField">The FsTableField to get the data cells from.</param>
-    static member getDataCells cellsCollection showHeaderRow (tableField : FsTableField) =
-        tableField.DataCells(cellsCollection, showHeaderRow)
+    static member getDataCells cellsCollection (tableField : FsTableField) =
+        tableField.DataCells(cellsCollection)

--- a/src/FsSpreadsheet/Tables/FsTableField.fs
+++ b/src/FsSpreadsheet/Tables/FsTableField.fs
@@ -127,7 +127,6 @@ type FsTableField (name : string, index : int, column : FsRangeColumn, totalsRow
     /// Gets the collection of data cells for this FsTableField. Excludes the header and footer cells.
     /// </summary>
     /// <param name="cellsCollection">The FsCellsCollection respective to the FsTableField where the data cells are taken from.</param>
-    /// <param name="showHeaderRow">If the header row is shown or not.</param>
     member this.DataCells (cellsCollection : FsCellsCollection) =        
         this.Column.Cells(cellsCollection)
         |> Seq.skip 1 // ClosedXML implementation never shows header cell
@@ -136,7 +135,6 @@ type FsTableField (name : string, index : int, column : FsRangeColumn, totalsRow
     /// Gets the collection of data cells for a given FsTableField. Excludes the header and footer cells.
     /// </summary>
     /// <param name="cellsCollection">The FsCellsCollection respective to the FsTableField where the data cells are taken from.</param>
-    /// <param name="showHeaderRow">If the header row is shown or not.</param>
     /// <param name="tableField">The FsTableField to get the data cells from.</param>
     static member getDataCells cellsCollection (tableField : FsTableField) =
         tableField.DataCells(cellsCollection)

--- a/src/FsSpreadsheet/Tables/FsTableField.fs
+++ b/src/FsSpreadsheet/Tables/FsTableField.fs
@@ -132,7 +132,7 @@ type FsTableField (name : string, index : int, column : FsRangeColumn, totalsRow
         // TO DO: Ask HLW: isn't this predicate pointless? If showHeaderRow is false, the code breaks as soon as trying to call .HeaderCell
         //let predicate cell = (not showHeaderRow) && (this.HeaderCell(cellsCollection, showHeaderRow) <> cell)
         let predicate = fun _ -> true
-        this.Column.Cells(cellsCollection, predicate)
+        this.Column.CellsSelect(cellsCollection, predicate)
         |> Seq.skip 1       // ClosedXML implementation never shows header cell
 
     /// <summary>

--- a/tests/FsSpreadsheet.ExcelIO.Tests/FsSpreadsheet.ExcelIO.Tests.fsproj
+++ b/tests/FsSpreadsheet.ExcelIO.Tests/FsSpreadsheet.ExcelIO.Tests.fsproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
@@ -16,10 +16,14 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Expecto" Version="9.*" />
+    <PackageReference Include="Expecto" Version="10.1.0" />
     <PackageReference Include="YoloDev.Expecto.TestSdk" Version="0.*" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.*" />
     <ProjectReference Include="..\..\src\FsSpreadsheet.ExcelIO\FsSpreadsheet.ExcelIO.fsproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Update="FSharp.Core" Version="7.0.300" />
   </ItemGroup>
 
 </Project>

--- a/tests/FsSpreadsheet.ExcelIO.Tests/Main.fs
+++ b/tests/FsSpreadsheet.ExcelIO.Tests/Main.fs
@@ -3,4 +3,4 @@ open Expecto
 
 [<EntryPoint>]
 let main argv =
-    Tests.runTestsInAssembly defaultConfig argv
+    Tests.runTestsInAssemblyWithCLIArgs [] argv

--- a/tests/FsSpreadsheet.Tests/FsColumn.fs
+++ b/tests/FsSpreadsheet.Tests/FsColumn.fs
@@ -39,7 +39,7 @@ let main =
         ]
         testList "ColumnFromIndex" [
             let dummyWorkSheet = getDummyWorkSheet()
-            let column = FsColumn(2, dummyWorkSheet.CellCollection)
+            let column = FsColumn.createAt(2, dummyWorkSheet.CellCollection)
             testCase "CorrectIndex" <| fun _ ->
                 Expect.equal column.Index 2 "Column index is not correct"
             testCase "CorrectRange" <| fun _ ->
@@ -56,16 +56,22 @@ let main =
             let dummyWorkSheet = getDummyWorkSheet()
             testCase "CorrectColumnCount" <| fun _ ->
                 Expect.equal (dummyWorkSheet.Columns |> Seq.length) 3 "Column count is not correct"
+            testCase "DoesNotFail" <| fun _ ->
+                let c = dummyWorkSheet.Column(2)
+                Expect.equal 1 1 "Failed when retreiving column"
+            testCase "HasRangeAddress" <| fun _ ->
+                let c = dummyWorkSheet.Column(2)
+                Expect.equal c.RangeAddress.Range "B1:B3" "Column range is not correct"
             testCase "CorrectIndex" <| fun _ ->
                 Expect.equal (dummyWorkSheet.Column(2).Index) 2 "Column index is not correct"
         ]
         testList "FromTableRetrieval" [
             
             testCase "CorrectColumnCount" <| fun _ ->
-                let columns = FsTable.dummyFsTable.Columns(FsTable.dummyFsCellsCollection)
+                let columns = FsTable.dummyFsTable.GetColumns(FsTable.dummyFsCellsCollection)
                 Expect.equal (columns |> Seq.length) (FsTable.dummyFsTable.ColumnCount()) "Column count is not correct"
             testCase "Correct values" <| fun _ ->
-                let columns = FsTable.dummyFsTable.Columns(FsTable.dummyFsCellsCollection)
+                let columns = FsTable.dummyFsTable.GetColumns(FsTable.dummyFsCellsCollection)
                 let expectedValues = ["Name";"John Doe";"Jane Doe";"Jack Doe"]
                 Expect.mySequenceEqual (Seq.item 0 columns |> Seq.map FsCell.getValueAs<string>) expectedValues "Values are not correct"
         ]

--- a/tests/FsSpreadsheet.Tests/FsSpreadsheet.Tests.fsproj
+++ b/tests/FsSpreadsheet.Tests/FsSpreadsheet.Tests.fsproj
@@ -31,4 +31,8 @@
   <ItemGroup>
     <ProjectReference Include="..\..\src\FsSpreadsheet\FsSpreadsheet.fsproj" />
   </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Update="FSharp.Core" Version="7.0.300" />
+  </ItemGroup>
 </Project>

--- a/tests/FsSpreadsheet.Tests/FsTable.fs
+++ b/tests/FsSpreadsheet.Tests/FsTable.fs
@@ -85,7 +85,7 @@ let main =
                 let testFsTable = FsTable("testFsTable", FsRangeAddress(dummyFsCellsCollectionFirstAddress, dummyFsCellsCollectionLastAddress))
                 testFsTable.AddFields dummyFsTableFields |> ignore
                 let testNames, testIndeces = 
-                    testFsTable.Fields dummyFsCellsCollection 
+                    testFsTable.GetFields(dummyFsCellsCollection)
                     |> Seq.map (fun tf -> tf.Name, tf.Index) 
                     |> Seq.toArray 
                     |> Array.unzip
@@ -102,7 +102,7 @@ let main =
         ]
         testList "TryGetHeaderCellOfColumn" [
             testList "cellsCollection : FsCellsCollection, colIndex : int" [
-                let testHeaderCell = dummyFsTable.TryGetHeaderCellOfColumn(dummyFsCellsCollection, 3)
+                let testHeaderCell = dummyFsTable.TryGetHeaderCellOfColumnAt(dummyFsCellsCollection, 3)
                 testCase "Is Some" <| fun _ ->
                     Expect.isSome testHeaderCell "Is None"
                 testCase "Has correct value" <| fun _ ->
@@ -122,7 +122,7 @@ let main =
             testList "cellsCollection : FsCellsCollection, tableFieldIndex : int" [
                 let testFsTable = FsTable("testFsTable", FsRangeAddress(dummyFsCellsCollectionFirstAddress, dummyFsCellsCollectionLastAddress))
                 testFsTable.AddFields dummyFsTableFields
-                let testHeaderCell = testFsTable.TryGetHeaderCellOfTableField(dummyFsCellsCollection, 1)
+                let testHeaderCell = testFsTable.TryGetHeaderCellOfTableFieldAt(dummyFsCellsCollection, 1)
                 testCase "Is Some" <| fun _ ->
                     Expect.isSome testHeaderCell "Is None"
                 testCase "Has correct value" <| fun _ ->
@@ -156,7 +156,7 @@ let main =
             testList "cellsCollection : FsCellsCollection, fieldName : FsTableField" [
                 let testFsTable = FsTable("testFsTable", FsRangeAddress(dummyFsCellsCollectionFirstAddress, dummyFsCellsCollectionLastAddress))
                 testFsTable.AddFields dummyFsTableFields
-                let testDataCells = testFsTable.GetDataCellsOfColumn(dummyFsCellsCollection, 2)
+                let testDataCells = testFsTable.GetDataCellsOfColumnAt(dummyFsCellsCollection, 2)
                 testCase "Is Some" <| fun _ ->
                     Expect.isNonEmpty testDataCells "Seq is empty"
                 testCase "Has correct values" <| fun _ ->

--- a/tests/FsSpreadsheet.Tests/FsTableField.fs
+++ b/tests/FsSpreadsheet.Tests/FsTableField.fs
@@ -147,7 +147,7 @@ let main =
                 testFsCellsCollection.Add testFsCells |> ignore
                 testList "showHeaderRow = true" [
                     testCase "Returns correct data cells" <| fun _ ->
-                        let dataCells = testFsTableField.DataCells(testFsCellsCollection, true)
+                        let dataCells = testFsTableField.DataCells(testFsCellsCollection)
                         let dataCellsVals = dataCells |> Seq.map (fun c -> c.Value)
                         let col3Cells = testFsCellsCollection.GetCellsInColumn 3
                         let col3CellsNoHeader = col3Cells |> Seq.skip 1


### PR DESCRIPTION
Added `[<AttachMembers>]` attribute to user-facing classes. For this, some adjustments had to be done:

- `Removed alternative constructors` and replaced either with `optional parameters` or static `create` members where applicable.
  e.g.: https://github.com/CSBiology/FsSpreadsheet/compare/fable#diff-a0445897c1a46d0268c91e3f173aae95820bf3777e9eeacca6eb89bbaffd85daL19
- `Removed overloaded members` and replaced either with `optional parameters` or more descriptively named (static) members where applicable.
  e.g.: https://github.com/CSBiology/FsSpreadsheet/compare/fable#diff-e8ae51728d61d1363f9981485f767b15c168763f6f0ccb7e6ac8bed912b4db1aL42
- `Replaced fields with parametrized getters` and replaced with explicit methods
 e.g.: https://github.com/CSBiology/FsSpreadsheet/compare/fable#diff-a0445897c1a46d0268c91e3f173aae95820bf3777e9eeacca6eb89bbaffd85daL19
 
Could not add `[<AttachMembers>]` attribute to `FsCell`, as there is a (necessarily) inlined method which does not currently work together. See issue https://github.com/fable-compiler/Fable/issues/2824