### PR TITLE
Fix table transform

### DIFF
--- a/src/FsSpreadsheet.ExcelIO/FsExtensions.fs
+++ b/src/FsSpreadsheet.ExcelIO/FsExtensions.fs
@@ -78,7 +78,8 @@ module FsExtensions =
         static member fromXlsxTable table = 
             let topLeftBoundary, bottomRightBoundary = Table.getArea table |> Table.Area.toBoundaries
             let ra = FsRangeAddress(FsAddress(topLeftBoundary), FsAddress(bottomRightBoundary))
-            FsTable(table.Name, ra, table.TotalsRowShown, true)
+            let totalsRowShown = if table.TotalsRowShown = null then false else table.TotalsRowShown.Value
+            FsTable(table.Name, ra, totalsRowShown, true)
 
         /// <summary>
         /// Returns the FsWorksheet associated with the FsTable in a given FsWorkbook.

--- a/tests/FsSpreadsheet.ExcelIO.Tests/FsSpreadsheet.ExcelIO.Tests.fsproj
+++ b/tests/FsSpreadsheet.ExcelIO.Tests/FsSpreadsheet.ExcelIO.Tests.fsproj
@@ -14,6 +14,7 @@
     <Compile Include="OpenXml\Sheet.fs" />
     <Compile Include="OpenXml\Workbook.fs" />
     <Compile Include="OpenXml\Spreadsheet.fs" />
+    <Compile Include="Table.fs" />
     <Compile Include="FsWorkbook.fs" />
     <Compile Include="Main.fs" />
   </ItemGroup>

--- a/tests/FsSpreadsheet.ExcelIO.Tests/Table.fs
+++ b/tests/FsSpreadsheet.ExcelIO.Tests/Table.fs
@@ -1,0 +1,25 @@
+﻿module FsTable
+
+open Expecto
+open FsSpreadsheet
+open FsSpreadsheet.ExcelIO
+open DocumentFormat.OpenXml
+open TestingUtils
+
+
+let transformTable =
+    testList "transformTable" [
+        testCase "handleNullFields" (fun () ->
+            let table = FsSpreadsheet.ExcelIO.Table.create "TestTable" (StringValue ("A1:D4")) []
+            Expect.isTrue (table.TotalsRowShown = null) "Check that field of interest is None"
+            FsTable.fromXlsxTable table |> ignore
+            )
+    
+    ]
+    
+
+[<Tests>]
+let main =
+    testList "FsTable" [
+        transformTable
+    ]


### PR DESCRIPTION
closes #42 
The problem was, that the table reader tried to access the value of an OpenXml null field and calling the FsTable constructor with this null value.